### PR TITLE
Make `drivers.yaml` file optional

### DIFF
--- a/collectors/collectors.go
+++ b/collectors/collectors.go
@@ -61,6 +61,7 @@ func ResolveFilepaths() error {
 		resolveSriovDevFilepaths,
 		resolveKubePodCPUFilepaths,
 		resolveKubePodDeviceFilepaths,
+		resolveSupportedDriverVersionDbPath,
 	}
 
 	for _, resolveFunc := range resolveFuncs {

--- a/collectors/sriovdev_readers_test.go
+++ b/collectors/sriovdev_readers_test.go
@@ -21,7 +21,7 @@ var _ = DescribeTable("test getting stats reader for pf", // getStatsReader
 		}
 
 		// TODO: replace with fstest.MapFS entry
-		supportedDrivers = drvinfo.SupportedDrivers{Drivers: drvinfo.DriversList{Drivers: []drvinfo.DriverInfo{*driver}}, DbFilePath: ""}
+		supportedDrivers = &drvinfo.SupportedDriversDbFile{Drivers: drvinfo.DriversList{Drivers: []drvinfo.DriverInfo{*driver}}, DbFilePath: ""}
 
 		statsReader := getStatsReader(pf, priority)
 

--- a/collectors/testdata/supported-drivers-version-db.yaml
+++ b/collectors/testdata/supported-drivers-version-db.yaml
@@ -1,0 +1,5 @@
+drivers:
+  - name: ice
+    version: 1.9.11
+  - name: mlx5_core
+    version: 5.15.0-53-generic

--- a/deployment/daemonset.yaml
+++ b/deployment/daemonset.yaml
@@ -40,6 +40,7 @@ spec:
         - --path.kubeletsocket=/host/kubelet.sock
         - --collector.kubepoddevice=true
         - --collector.vfstatspriority=sysfs,netlink
+        - --path.supported-drivers-version-db=/etc/sriov-network-metrics-exporter/drivers.yaml
         image: localhost:5000/sriov-metrics-exporter
         imagePullPolicy: Always 
         name: sriov-metrics-exporter

--- a/pkg/drvinfo/drvinfo.go
+++ b/pkg/drvinfo/drvinfo.go
@@ -32,13 +32,17 @@ type DriversList struct {
 	Drivers []DriverInfo
 }
 
-type SupportedDrivers struct {
+type SupportedDrivers interface {
+	IsDriverSupported(drv *DriverInfo) bool
+}
+
+type SupportedDriversDbFile struct {
 	Drivers    DriversList
 	DbFilePath string
 }
 
 var NewSupportedDrivers = func(fp string) SupportedDrivers {
-	retv := SupportedDrivers{}
+	retv := &SupportedDriversDbFile{}
 	supportedDrivers, err := readSupportedDrivers(fp)
 	if err != nil {
 		log.Printf("fetching supported drivers list from %s failed with error %v", fp, err)
@@ -65,7 +69,7 @@ var GetDriverInfo = func(name string) (*DriverInfo, error) {
 	}, nil
 }
 
-func (dl *SupportedDrivers) IsDriverSupported(drv *DriverInfo) bool {
+func (dl *SupportedDriversDbFile) IsDriverSupported(drv *DriverInfo) bool {
 	for _, d := range dl.Drivers.Drivers {
 		if d.Name != drv.Name {
 			continue
@@ -102,4 +106,14 @@ func readSupportedDrivers(filePath string) (*DriversList, error) {
 		return drivers, err
 	}
 	return drivers, nil
+}
+
+func NewStubSupportedDrivers() SupportedDrivers {
+	return &StubSupportedDrivers{}
+}
+
+type StubSupportedDrivers struct{}
+
+func (ssp *StubSupportedDrivers) IsDriverSupported(drv *DriverInfo) bool {
+	return true
 }


### PR DESCRIPTION
Change the path to the `drivers.yaml` from a constant to a user-definable parameter `path.supported-drivers-version-db`. If the user does not specify any value for the file path, then every ethernet driver is considered good to use.

@SchSeba @Eoghan1232 please take a look