### PR TITLE
Remove references to the driver ConfigMap

### DIFF
--- a/deployment/daemonset.yaml
+++ b/deployment/daemonset.yaml
@@ -61,8 +61,6 @@ spec:
         - mountPath: /host/cpu_manager_state
           name: cpucheckpoint
           readOnly: true
-        - name: sriov-network-metrics-exporter
-          mountPath: /etc/sriov-network-metrics-exporter
       nodeSelector:
         kubernetes.io/os: linux
         feature.node.kubernetes.io/network-sriov.capable: "true"
@@ -94,9 +92,6 @@ spec:
           path: /sys/devices
           type: "Directory"
         name: sysdevices
-      - name: sriov-network-metrics-exporter
-        configMap:
-          name: sriov-network-metrics-exporter
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
As a leftover of:
- Remove driver version check  #37

the daemonset deployment file must be updated
removing  related references.

cc @Eoghan1232, @SchSeba, @balaramvedulla

fixes:
- https://github.com/k8snetworkplumbingwg/sriov-network-metrics-exporter/issues/38
