### PR TITLE
Changing volume types: type: "Directory" to type: "DirectoryOrCreate" to avoid "hostPath type check failed" error

### DIFF
--- a/deployment/daemonset.yaml
+++ b/deployment/daemonset.yaml
@@ -74,7 +74,7 @@ spec:
         name: kubeletsocket
       - hostPath:
           path: /sys/fs/cgroup/cpuset/kubepods.slice/
-          type: "Directory"
+          type: "DirectoryOrCreate"
         name: kubecgroup
       - hostPath:
           path: /var/lib/kubelet/cpu_manager_state
@@ -82,15 +82,15 @@ spec:
         name: cpucheckpoint
       - hostPath:
           path: /sys/class/net
-          type: "Directory"
+          type: "DirectoryOrCreate"
         name: sysclassnet
       - hostPath:
           path: /sys/bus/pci/devices
-          type: "Directory"
+          type: "DirectoryOrCreate"
         name: sysbuspcidevices
       - hostPath:
           path: /sys/devices
-          type: "Directory"
+          type: "DirectoryOrCreate"
         name: sysdevices
 ---
 apiVersion: v1


### PR DESCRIPTION
Changing volume types: type: "Directory" to type: "DirectoryOrCreate" to avoid "hostPath type check failed" error.

With this volume type, we can avoid "MountVolume.SetUp failed for volume "kubecgroup" : hostPath type check failed: /sys/fs/cgroup/cpuset/kubepods.slice/ is not a directory"

This way if the volume directory is not present, the directory will be created.
I tested in my deployment and it works well.