### PR TITLE
Fallback on collecter if first one is found but does not work

### DIFF
--- a/collectors/sriovdev.go
+++ b/collectors/sriovdev.go
@@ -144,9 +144,14 @@ func getSriovDev(pfAddr string, priority []string) sriovDev {
 		log.Printf("error getting vf address\n%v", err)
 	}
 
+	reader, err := getStatsReader(name, priority)
+	if err != nil {
+		log.Printf("error getting stats reader for %s: %v", name, err)
+	}
+
 	return sriovDev{
 		name,
-		getStatsReader(name, priority),
+		reader,
 		vfs,
 	}
 }

--- a/collectors/sriovdev_readers.go
+++ b/collectors/sriovdev_readers.go
@@ -35,9 +35,15 @@ type sysfsReader struct {
 	statsFS string
 }
 
+// check if a reader can read stats for a given pf and vfID
+func readerHasStats(reader sriovStatReader, pfName, vfID string) bool {
+	stats := reader.ReadStats(pfName, vfID)
+	return len(stats) > 0
+}
+
 // getStatsReader returns the correct stat reader for the given PF
 // Currently only drivers that implement netlink or the sriov sysfs interface are supported
-func getStatsReader(pf string, priority []string) sriovStatReader {
+func getStatsReader(pf string, priority []string) (sriovStatReader, error) {
 	// Try to find a collector that can actually read stats for at least VF 0
 	vfTestID := "0"
 	for _, collector := range priority {
@@ -46,9 +52,9 @@ func getStatsReader(pf string, priority []string) sriovStatReader {
 			if _, err := fs.Stat(netfs, filepath.Join(pf, "/device/sriov")); !os.IsNotExist(err) {
 				reader := sysfsReader{filepath.Join(*sysClassNet, "%s/device/sriov/%s/stats/")}
 				// Test if sysfsReader can read stats for VF 0
-				if stats := reader.ReadStats(pf, vfTestID); len(stats) > 0 {
+				if readerHasStats(reader, pf, vfTestID) {
 					log.Printf("%s - using sysfs collector", pf)
-					return reader
+					return reader, nil
 				} else {
 					log.Printf("%s - sysfs collector present but no stats found for vf%s", pf, vfTestID)
 				}
@@ -59,9 +65,9 @@ func getStatsReader(pf string, priority []string) sriovStatReader {
 			if vfstats.DoesPfSupportNetlink(pf) {
 				reader := netlinkReader{vfstats.VfStats(pf)}
 				// Test if netlinkReader can read stats for VF 0
-				if stats := reader.ReadStats(pf, vfTestID); len(stats) > 0 {
+				if readerHasStats(reader, pf, vfTestID) {
 					log.Printf("%s - using netlink collector", pf)
-					return reader
+					return reader, nil
 				} else {
 					log.Printf("%s - netlink collector present but no stats found for vf%s", pf, vfTestID)
 				}
@@ -72,7 +78,7 @@ func getStatsReader(pf string, priority []string) sriovStatReader {
 			log.Printf("%s - '%s' collector not supported", pf, collector)
 		}
 	}
-	return nil
+	return nil, fmt.Errorf("no stats reader found for %s", pf)
 }
 
 // ReadStats takes in the name of a PF and the VF Id and returns a stats object.

--- a/collectors/sriovdev_readers.go
+++ b/collectors/sriovdev_readers.go
@@ -38,22 +38,36 @@ type sysfsReader struct {
 // getStatsReader returns the correct stat reader for the given PF
 // Currently only drivers that implement netlink or the sriov sysfs interface are supported
 func getStatsReader(pf string, priority []string) sriovStatReader {
+	// Try to find a collector that can actually read stats for at least VF 0
+	vfTestID := "0"
 	for _, collector := range priority {
 		switch collector {
 		case "sysfs":
 			if _, err := fs.Stat(netfs, filepath.Join(pf, "/device/sriov")); !os.IsNotExist(err) {
-				log.Printf("%s - using sysfs collector", pf)
-				return sysfsReader{filepath.Join(*sysClassNet, "%s/device/sriov/%s/stats/")}
+				reader := sysfsReader{filepath.Join(*sysClassNet, "%s/device/sriov/%s/stats/")}
+				// Test if sysfsReader can read stats for VF 0
+				if stats := reader.ReadStats(pf, vfTestID); len(stats) > 0 {
+					log.Printf("%s - using sysfs collector", pf)
+					return reader
+				} else {
+					log.Printf("%s - sysfs collector present but no stats found for vf%s", pf, vfTestID)
+				}
+			} else {
+				log.Printf("%s does not support sysfs collector, directory '%s' does not exist", pf, filepath.Join(pf, "/device/sriov"))
 			}
-
-			log.Printf("%s does not support sysfs collector, directory '%s' does not exist", pf, filepath.Join(pf, "/device/sriov"))
 		case "netlink":
 			if vfstats.DoesPfSupportNetlink(pf) {
-				log.Printf("%s - using netlink collector", pf)
-				return netlinkReader{vfstats.VfStats(pf)}
+				reader := netlinkReader{vfstats.VfStats(pf)}
+				// Test if netlinkReader can read stats for VF 0
+				if stats := reader.ReadStats(pf, vfTestID); len(stats) > 0 {
+					log.Printf("%s - using netlink collector", pf)
+					return reader
+				} else {
+					log.Printf("%s - netlink collector present but no stats found for vf%s", pf, vfTestID)
+				}
+			} else {
+				log.Printf("%s does not support netlink collector", pf)
 			}
-
-			log.Printf("%s does not support netlink collector", pf)
 		default:
 			log.Printf("%s - '%s' collector not supported", pf, collector)
 		}

--- a/collectors/sriovdev_readers_test.go
+++ b/collectors/sriovdev_readers_test.go
@@ -37,7 +37,10 @@ var _ = DescribeTable("test getting stats reader for pf", // getStatsReader
 	Entry("with sysfs support",
 		"ens785f0",
 		[]string{"sysfs", "netlink"},
-		fstest.MapFS{"ens785f0/device/sriov": {Mode: fs.ModeDir}},
+		fstest.MapFS{
+			"ens785f0/device/sriov":                    {Mode: fs.ModeDir},
+			"ens785f0/device/sriov/0/stats/rx_packets": {Data: []byte("1")}, // Added to enable sysfsReader
+		},
 		nil,
 		sysfsReader{"/sys/class/net/%s/device/sriov/%s/stats"},
 		"ens785f0 - using sysfs collector"),

--- a/collectors/sriovdev_readers_test.go
+++ b/collectors/sriovdev_readers_test.go
@@ -24,12 +24,14 @@ var _ = DescribeTable("test getting stats reader for pf", // getStatsReader
 			})
 		}
 
-		statsReader := getStatsReader(pf, priority)
+		statsReader, err := getStatsReader(pf, priority)
 
 		if expected != nil {
 			Expect(statsReader).To(Equal(expected))
+			Expect(err).To(BeNil())
 		} else {
 			Expect(statsReader).To(BeNil())
+			Expect(err).To(HaveOccurred())
 		}
 
 		assertLogs(logs)

--- a/collectors/sriovdev_test.go
+++ b/collectors/sriovdev_test.go
@@ -3,7 +3,6 @@ package collectors
 import (
 	"fmt"
 	"io/fs"
-	"net"
 	"testing/fstest"
 
 	"github.com/k8snetworkplumbingwg/sriov-network-metrics-exporter/pkg/vfstats"
@@ -83,8 +82,9 @@ var _ = DescribeTable("test vf stats collection", // Collect
 			"0000:2e:00.0/virtfn0":        {Data: []byte("/sys/devices/0000:2e:01.0"), Mode: fs.ModeSymlink},
 			"0000:2e:00.0/virtfn1":        {Data: []byte("/sys/devices/0000:2e:01.1"), Mode: fs.ModeSymlink}},
 		netlink.Device{LinkAttrs: netlink.LinkAttrs{Vfs: []netlink.VfInfo{
-			{0, net.HardwareAddr{}, 0, 0, 0, true, 0, 0, 0, 11, 12, 13, 14, 15, 16, 17, 18, 0, 0},    //nolint:govet
-			{1, net.HardwareAddr{}, 0, 0, 0, true, 0, 0, 0, 21, 22, 23, 24, 25, 26, 27, 28, 0, 0}}}}, //nolint:govet
+			{ID: 0, Mac: nil, Vlan: 0, Qos: 0, TxRate: 0, Spoofchk: true, LinkState: 0, MaxTxRate: 0, MinTxRate: 0, RxPackets: 11, TxPackets: 12, RxBytes: 13, TxBytes: 14, Multicast: 15, Broadcast: 16, RxDropped: 17, TxDropped: 18, RssQuery: 0, Trust: 0},
+			{ID: 1, Mac: nil, Vlan: 0, Qos: 0, TxRate: 0, Spoofchk: true, LinkState: 0, MaxTxRate: 0, MinTxRate: 0, RxPackets: 21, TxPackets: 22, RxBytes: 23, TxBytes: 24, Multicast: 25, Broadcast: 26, RxDropped: 27, TxDropped: 28, RssQuery: 0, Trust: 0},
+		}}},
 		[]metric{
 			{map[string]string{"numa_node": "0", "pciAddr": "0000:2e:01.0", "pf": "t_ens801f0", "vf": "0"}, 11},
 			{map[string]string{"numa_node": "0", "pciAddr": "0000:2e:01.0", "pf": "t_ens801f0", "vf": "0"}, 12},
@@ -121,7 +121,8 @@ var _ = DescribeTable("test vf stats collection", // Collect
 			"0000:4g:00.0/class":                         {Data: []byte("0x020000")},
 			"0000:4g:00.0/virtfn0":                       {Data: []byte("/sys/devices/0000:4g:01.0"), Mode: fs.ModeSymlink}},
 		netlink.Device{LinkAttrs: netlink.LinkAttrs{Vfs: []netlink.VfInfo{
-			{0, net.HardwareAddr{}, 0, 0, 0, true, 0, 0, 0, 31, 32, 33, 34, 35, 36, 37, 38, 0, 0}}}}, //nolint:govet
+			{ID: 0, Mac: nil, Vlan: 0, Qos: 0, TxRate: 0, Spoofchk: true, LinkState: 0, MaxTxRate: 0, MinTxRate: 0, RxPackets: 31, TxPackets: 32, RxBytes: 33, TxBytes: 34, Multicast: 35, Broadcast: 36, RxDropped: 37, TxDropped: 38, RssQuery: 0, Trust: 0},
+		}}},
 		[]metric{
 			{map[string]string{"numa_node": "0", "pciAddr": "0000:3f:01.0", "pf": "t_ens785f0", "vf": "0"}, 4},
 			{map[string]string{"numa_node": "0", "pciAddr": "0000:3f:01.0", "pf": "t_ens785f0", "vf": "0"}, 8},
@@ -256,12 +257,13 @@ var _ = DescribeTable("test getting sriov dev details", // getSriovDev
 		"0000:4f:00.0",
 		[]string{"sysfs", "netlink"},
 		fstest.MapFS{
-			"0000:4f:00.0/net/ens785f0": {Mode: fs.ModeDir},
-			"0000:4f:00.0/virtfn0":      {Data: []byte("/sys/devices/0000:4f:01.0"), Mode: fs.ModeSymlink},
-			"0000:4f:00.0/virtfn1":      {Data: []byte("/sys/devices/0000:4f:01.1"), Mode: fs.ModeSymlink},
-			"ens785f0/device/sriov":     {Mode: fs.ModeDir}, // Added to enable sysfs reader
-			"0000:5g:00.0/net/ens801f0": {Mode: fs.ModeDir},
-			"0000:5g:00.0/virtfn0":      {Data: []byte("/sys/devices/0000:5g:01.0"), Mode: fs.ModeSymlink}},
+			"0000:4f:00.0/net/ens785f0":                {Mode: fs.ModeDir},
+			"0000:4f:00.0/virtfn0":                     {Data: []byte("/sys/devices/0000:4f:01.0"), Mode: fs.ModeSymlink},
+			"0000:4f:00.0/virtfn1":                     {Data: []byte("/sys/devices/0000:4f:01.1"), Mode: fs.ModeSymlink},
+			"ens785f0/device/sriov":                    {Mode: fs.ModeDir},
+			"ens785f0/device/sriov/0/stats/rx_packets": {Data: []byte("1")}, // Added to enable sysfsReader
+			"0000:5g:00.0/net/ens801f0":                {Mode: fs.ModeDir},
+			"0000:5g:00.0/virtfn0":                     {Data: []byte("/sys/devices/0000:5g:01.0"), Mode: fs.ModeSymlink}},
 		nil,
 		sriovDev{
 			"ens785f0",

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/onsi/gomega v1.24.0
 	github.com/prometheus/client_golang v1.12.1
 	github.com/prometheus/client_model v0.2.0
-	github.com/vishvananda/netlink v1.1.1-0.20201029203352-d40f9887b852
+	github.com/vishvananda/netlink v1.3.1
 	golang.org/x/time v0.0.0-20220210224613-90d013bbcef8
 	google.golang.org/grpc v1.56.3
 	k8s.io/kubelet v0.25.5
@@ -23,7 +23,7 @@ require (
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/prometheus/common v0.32.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
-	github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae // indirect
+	github.com/vishvananda/netns v0.0.5 // indirect
 	golang.org/x/net v0.33.0 // indirect
 	golang.org/x/sys v0.28.0 // indirect
 	golang.org/x/text v0.21.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -199,12 +199,8 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/vishvananda/netlink v1.1.1-0.20201029203352-d40f9887b852 h1:cPXZWzzG0NllBLdjWoD1nDfaqu98YMv+OneaKc8sPOA=
-github.com/vishvananda/netlink v1.1.1-0.20201029203352-d40f9887b852/go.mod h1:twkDnbuQxJYemMlGd4JFIcuhgX83tXhKS2B/PRMpOho=
 github.com/vishvananda/netlink v1.3.1 h1:3AEMt62VKqz90r0tmNhog0r/PpWKmrEShJU0wJW6bV0=
 github.com/vishvananda/netlink v1.3.1/go.mod h1:ARtKouGSTGchR8aMwmkzC0qiNPrrWO5JS/XMVl45+b4=
-github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae h1:4hwBBUfQCFe3Cym0ZtKyq7L16eZUtYKs+BaHDN6mAns=
-github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 github.com/vishvananda/netns v0.0.5 h1:DfiHV+j8bA32MFM7bfEunvT8IAqQ/NzSJHtcmW5zdEY=
 github.com/vishvananda/netns v0.0.5/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -320,7 +316,6 @@ golang.org/x/sys v0.0.0-20200113162924-86b910548bc1/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200122134326-e047566fdf82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200217220822-9197077df867/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -331,7 +326,6 @@ golang.org/x/sys v0.0.0-20200515095857-1151b9dac4a9/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/go.sum
+++ b/go.sum
@@ -201,8 +201,12 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/vishvananda/netlink v1.1.1-0.20201029203352-d40f9887b852 h1:cPXZWzzG0NllBLdjWoD1nDfaqu98YMv+OneaKc8sPOA=
 github.com/vishvananda/netlink v1.1.1-0.20201029203352-d40f9887b852/go.mod h1:twkDnbuQxJYemMlGd4JFIcuhgX83tXhKS2B/PRMpOho=
+github.com/vishvananda/netlink v1.3.1 h1:3AEMt62VKqz90r0tmNhog0r/PpWKmrEShJU0wJW6bV0=
+github.com/vishvananda/netlink v1.3.1/go.mod h1:ARtKouGSTGchR8aMwmkzC0qiNPrrWO5JS/XMVl45+b4=
 github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae h1:4hwBBUfQCFe3Cym0ZtKyq7L16eZUtYKs+BaHDN6mAns=
 github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
+github.com/vishvananda/netns v0.0.5 h1:DfiHV+j8bA32MFM7bfEunvT8IAqQ/NzSJHtcmW5zdEY=
+github.com/vishvananda/netns v0.0.5/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -335,6 +339,8 @@ golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.28.0 h1:Fksou7UEQUWlKvIdsqzJmUmCX3cZuD2+P3XyyzwMhlA=
 golang.org/x/sys v0.28.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/pkg/vfstats/netlink.go
+++ b/pkg/vfstats/netlink.go
@@ -9,7 +9,7 @@ import (
 
 // PerPF returns stats related to each virtual function for a given physical function
 type PerPF struct {
-	pf  string
+	Pf  string
 	Vfs map[int]netlink.VfInfo
 }
 


### PR DESCRIPTION
Fixes #48 

@zeeke I don't have a way to properly test this, but I think this is a quick fix for the issue
would you be able to test this? 

if the sysfs collector is present, check if we can get the stats on the first VF, if this fails, then we should fallback to the second collector and so on. 