### PR TITLE
update gitignore file to skip the vendor and the the right build fold…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Temporary Build Files
-build/
+/build/*
 bin/
 testbin/
 env


### PR DESCRIPTION
…er only

without this change if we use vendor there is a file that gets ignore

```
!! vendor/github.com/onsi/ginkgo/v2/ginkgo/build/
```