### PR TITLE
metrics-exporter: install curl in runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,6 @@ RUN make clean && make build
 
 FROM docker.io/alpine:3.22
 COPY --from=builder /usr/src/sriov-network-metrics-exporter/build/* /usr/bin/
-RUN apk update && apk add --no-cache ca-certificates && update-ca-certificates && apk add --no-cache openssl
+RUN apk update && apk add --no-cache ca-certificates && update-ca-certificates && apk add --no-cache openssl curl
 EXPOSE 9808
 ENTRYPOINT ["sriov-exporter"]


### PR DESCRIPTION
This pr fixes issue  https://github.com/k8snetworkplumbingwg/sriov-network-metrics-exporter/issues/99