### PR TITLE
Add .coderabbit.yaml for sriov-network-metrics-exporter

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,219 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: en-US
+early_access: false
+enable_free_tier: true
+
+reviews:
+  profile: chill
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  in_progress_fortune: false
+  review_status: true
+  collapse_walkthrough: false
+
+  path_filters:
+    - "!**/vendor/**"
+    - "!vendor/**"
+    - "!go.sum"
+
+  auto_review:
+    enabled: true
+    drafts: true
+
+  # ── Path instructions ────────────────────────────────────────
+  path_instructions:
+
+    # ── Go code — general ────────────────────────────────────────
+    - path: "**/*.go"
+      instructions: |
+        Go security and best practices:
+        - Never ignore error returns; wrap errors with context using fmt.Errorf("...: %w", err)
+        - Use stdlib crypto/* and golang.org/x/crypto; avoid third-party crypto libraries
+        - Integer overflow: bounds-check user-supplied sizes
+        - context.Context for cancellation and timeouts on all network/I/O operations
+        - Nil pointer checks on hardware info structs (PCI device info, VF stats,
+          netlink responses) before accessing fields — SR-IOV hardware discovery
+          can return incomplete data
+        - Use structured logging with appropriate verbosity levels
+        - Prometheus client_golang best practices: use descriptors, avoid
+          unbounded label cardinality, document all metric help strings
+
+    # ── Collectors — Prometheus collector implementations ─────────
+    - path: "collectors/**/*.go"
+      instructions: |
+        Prometheus collector review:
+        - Verify all collectors implement the prometheus.Collector interface correctly
+          (Describe and Collect methods)
+        - Metric naming must follow Prometheus conventions:
+          namespace "sriov", subsystem where appropriate (e.g., "vf"),
+          snake_case names, _total suffix for counters, base units
+        - Label hygiene: no unbounded cardinality (e.g., do not use raw PCI
+          addresses or pod UIDs as labels without careful consideration)
+        - Collect must be safe to call concurrently from multiple scrape goroutines
+        - Collect must not block indefinitely — use timeouts for sysfs/netlink reads
+        - Gracefully handle missing or inaccessible sysfs entries (device removed,
+          driver unbound, permission denied) — emit partial metrics, do not panic
+        - sysfs path construction: validate and sanitize all path components;
+          never construct paths from unvalidated input; guard against symlink
+          traversal outside /sys/bus/pci/devices/ and /sys/class/net/
+        - Netlink stat readers: handle ENODEV, EINVAL, and permission errors
+          gracefully; VFs may disappear between discovery and stat collection
+        - Kubelet gRPC collectors (pod_cpu_link, pod_dev_link): handle connection
+          failures, empty responses, and API version mismatches; use timeouts
+          on gRPC calls; cache results appropriately to avoid overloading kubelet
+
+    # ── VF stats netlink package ─────────────────────────────────
+    - path: "pkg/vfstats/**/*.go"
+      instructions: |
+        Netlink VF stats retrieval review:
+        - Uses vishvananda/netlink for VF statistics — verify correct usage
+          of netlink.LinkByName and VF stat parsing
+        - Error handling: PFs may not exist, VF indices may be out of range,
+          or the netlink call may fail due to permissions — handle all cases
+        - Thread safety: netlink calls should be safe for concurrent use
+        - Resource cleanup: ensure netlink sockets/handles are properly closed
+        - Performance: avoid repeated netlink calls for the same PF within
+          a single scrape cycle; batch or cache where possible
+
+    # ── Main entrypoint and HTTP server ──────────────────────────
+    - path: "cmd/**/*.go"
+      instructions: |
+        Main entrypoint review:
+        - HTTP server configuration: verify timeouts (read, write, idle) are set
+          to prevent slowloris and resource exhaustion attacks
+        - Flag validation: ensure CLI flags have sensible defaults and are
+          validated before use (e.g., port range, file paths)
+        - Graceful shutdown: verify the server handles SIGTERM/SIGINT and
+          drains active scrape connections before exiting
+        - Prometheus handler registration: verify /metrics endpoint uses
+          promhttp.HandlerFor with appropriate options (error handling, timeout)
+        - No sensitive data in flag defaults or help text
+
+    # ── Utility packages ─────────────────────────────────────────
+    - path: "pkg/utils/**/*.go"
+      instructions: |
+        Utility package review:
+        - Path resolution: verify symlink handling is safe and does not escape
+          expected directories (/sys, /proc)
+        - Input validation: all external inputs (file paths, PCI addresses,
+          device names) must be validated before use
+        - Error wrapping: provide context in error messages for debugging
+          sysfs/procfs access issues
+
+    # ── Unit tests ───────────────────────────────────────────────
+    - path: "**/*_test.go"
+      instructions: |
+        Unit test quality (Ginkgo v2 + Gomega):
+        - Use table-driven tests for validation logic with multiple cases
+        - Mock external dependencies (sysfs reads, netlink calls, kubelet gRPC)
+          rather than requiring real hardware or a live cluster
+        - Test error paths, not just happy paths — especially for missing
+          sysfs entries, permission errors, and netlink failures
+        - Test metric output format: verify metric names, labels, and values
+          match Prometheus conventions
+        - Single responsibility: each It block should test one behavior
+        - Assertions should include meaningful failure messages
+        - Test names must be stable and deterministic — no dynamic values
+
+    # ── Dockerfiles / container images ───────────────────────────
+    - path: "**/{Dockerfile,Containerfile}*"
+      instructions: |
+        Container image security:
+        - Multi-stage builds preferred; no build tools in final image
+        - USER non-root where possible (note: the exporter needs read access
+          to host sysfs and kubelet socket — verify UID/GID requirements)
+        - COPY specific files, not entire context
+        - No secrets in ENV, ARG, or COPY
+        - No package manager cache in final layer
+        - Verify the exposed port matches the default metrics port (9808)
+        - Alpine base image: verify no unnecessary packages are installed
+
+    # ── Kubernetes manifests ─────────────────────────────────────
+    - path: "deployment/**/*.{yaml,yml}"
+      instructions: |
+        If this is a Kubernetes manifest:
+        - securityContext: runAsNonRoot where possible, readOnlyRootFilesystem,
+          allowPrivilegeEscalation: false where applicable
+        - Drop ALL capabilities, add only what is required
+        - Resource limits (cpu, memory) on every container
+        - RBAC: least privilege; no cluster-admin for workloads
+        - Liveness + readiness probes defined
+        - automountServiceAccountToken: false unless needed
+
+        Metrics exporter specifics:
+        - DaemonSet: hostNetwork and host volume mounts for /sys are required
+          for sysfs access — verify justification is documented
+        - Service: verify Prometheus scrape annotations or ServiceMonitor
+          configuration if present
+        - Volume mounts: verify the exporter only mounts necessary host paths
+          (/sys/bus/pci/devices, /sys/class/net, kubelet socket) with readOnly
+        - Port configuration must match the exporter's default port (9808)
+
+    # ── Supply chain & dependencies ──────────────────────────────
+    - path: "**/go.mod"
+      instructions: |
+        Supply chain security:
+        - New dependencies: justify the need, check license compatibility
+        - Pin exact versions; verify no unnecessary indirect dependencies added
+        - Flag known CVEs (cross-ref osv.dev)
+        - Check for replace directives pointing to forks — ensure they are
+          intentional and documented
+        - Key dependencies to watch: prometheus/client_golang,
+          vishvananda/netlink, containernetworking/plugins
+
+    # ── CI/CD & GitHub Actions ───────────────────────────────────
+    - path: ".github/workflows/**/*"
+      instructions: |
+        CI/CD security:
+        - Pin actions by full SHA, not tag
+        - No secrets in logs; mask sensitive outputs
+        - Least privilege: minimize GITHUB_TOKEN permissions
+        - No pull_request_target with checkout of PR head
+        - Verify the CI pipeline covers: build, test, lint (golangci-lint),
+          hadolint, and multi-arch image builds
+        - Image build workflows: verify image tags and push targets are correct
+
+    # ── Cryptography files ───────────────────────────────────────
+    - path: "**/*{crypt,cipher,sign,hash,tls,ssl,cert,key,token}*"
+      instructions: |
+        Cryptographic security:
+        - Banned: MD5, SHA1, DES, RC4, 3DES, Blowfish, ECB mode
+        - Symmetric: AES-256-GCM or ChaCha20-Poly1305
+        - Signing: Ed25519 or ECDSA P-256+
+        - Constant-time comparison for all secret/token data
+        - No custom crypto; use vetted libraries only
+
+  # ── Security scanners ────────────────────────────────────────
+  tools:
+    gitleaks:
+      enabled: true
+    semgrep:
+      enabled: true
+    checkov:
+      enabled: true
+    hadolint:
+      enabled: true
+    trivy:
+      enabled: true
+    osvScanner:
+      enabled: true
+    actionlint:
+      enabled: true
+    ast-grep:
+      essential_rules: true
+
+# ── Knowledge base ───────────────────────────────────────────
+knowledge_base:
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      - "**/CONTRIBUTING.md"
+  issues:
+    scope: "auto"
+  pull_requests:
+    scope: "auto"
+
+chat:
+  auto_reply: true
+  art: false


### PR DESCRIPTION
## Summary

Adds a `.coderabbit.yaml` configuration file to enable and configure CodeRabbit AI-powered code reviews for the sriov-network-metrics-exporter project. The configuration is adapted from the sriov-network-operator's established CodeRabbit setup, tailored to the specific structure and concerns of a Prometheus metrics exporter for SR-IOV network devices.

## Key Changes

- **New `.coderabbit.yaml` configuration file** with comprehensive review settings for the project
- **Review profile set to "chill"** with free tier enabled, matching the sriov-network-operator's approach
- **Path-based review instructions** tailored to the metrics exporter codebase:
  - Go source code under `pkg/` — general Go best practices, error handling, concurrency safety
  - Prometheus collector code (`pkg/collector/`) — metric naming conventions (`sriov_vf_*`), label cardinality, `Describe`/`Collect` contract compliance
  - Sysfs reading code (`pkg/sysfs/`) — safe path construction, symlink handling, missing-file tolerance
  - Unit tests (`*_test.go`) — table-driven tests, mock/stub usage, no flaky assertions
  - Dockerfiles — multi-stage builds, minimal base images, non-root user, no secrets in layers
  - Go module files (`go.mod`, `go.sum`) — supply chain review, minimal dependencies, license compatibility
  - GitHub Actions workflows (`.github/workflows/`) — pinned action versions, least-privilege permissions, secret handling
  - Kubernetes manifests (`deployment/`) — resource limits, security contexts, health probes
  - Makefile — reproducible builds, phony targets, no hardcoded paths
- **Security-focused reviews** enabled with Gitleaks scanner for secret detection
- **Knowledge base integration** configured with Jira and Linear support (disabled by default)
- **Path filters** to skip auto-generated and vendor files from review

## Notable Implementation Decisions

- Removed operator-specific instructions (controllers, daemon, plugins, webhooks, bindata manifests) that are not relevant to this exporter project
- Added metrics-exporter-specific guidance around Prometheus conventions (metric naming with `sriov_vf_` prefix, `UNIT_*` constants, label cardinality warnings)
- Added sysfs-specific review instructions since the exporter reads SR-IOV VF statistics directly from `/sys/class/net/` paths
- Retained the same review profile ("chill"), tone settings, and general infrastructure review rules as the reference sriov-network-operator configuration for consistency across the k8snetworkplumbingwg organization

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added CodeRabbit configuration for automated code review and security scanning integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->